### PR TITLE
Add more lint rules for `if` statements

### DIFF
--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -13,6 +13,9 @@
         "checkLoops": false
       }
     ],
+    "curly": "error",
+    "no-else-return": "error",
+    "no-lonely-if": "error",
     "spaced-comment": ["warn", "always"],
     "capitalized-comments": [
       "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
I update rules after noticing some patterns during code review, which should be covered by linter.

JavaScript allows the omission of curly braces when a block contains only one statement.

However, it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.

Omission is noticed mostly with `if (<statement>) continue;` constructs, but curly braces should not be omitted.

Also if an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.

**Edit:** I have also added `no-else-return` to the list of rules, as I've noticed this pattern while doing code review. It means that constructs like
```js
if (x) {
  return y;
} else {
  return z;
}
```
should omit else branch and use `return` directly.