### PR TITLE
🔧 enable require-await in eslint

### DIFF
--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -23,7 +23,8 @@
         "ignoreConsecutiveComments": true,
         "ignorePattern": "prettier"
       }
-    ]
+    ],
+    "require-await": "error"
   },
   "overrides": [
     {


### PR DESCRIPTION
As mentioned here: https://github.com/UN-OCHA/hpc_service/pull/2146#discussion_r700312811

Probably a good idea to enable this rule.