### PR TITLE
🔖 Bump version to `v0.1.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
At first, I thought this needs major version increase, since we want to release dependency updates from #8, but according to semver:
> Given a version number MAJOR.MINOR.PATCH, increment the:
> 1. MAJOR version when you make incompatible API changes,
> 1. MINOR version when you add functionality in a backwards compatible manner, and
> 1. PATCH version when you make backwards compatible bug fixes.

We don't exactly make changes to how this repo is utilized. We still import config from here into other repos and that hasn't changed, even though we declared new dependencies with their major versions being updated.