### PR TITLE
Add `"curly": "error"` rule for TS files 

### DIFF
--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -45,6 +45,7 @@
       ],
       "plugins": ["@typescript-eslint"],
       "rules": {
+        "curly": "error",
         "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Even though this rule is already listed for all files, it seems some of the rules from `"extends"` for TS files overwrite `"curly"` rule, so it needs to be listed again.