### PR TITLE
Throw error is triple equals is not used

### DIFF
--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -14,6 +14,7 @@
       }
     ],
     "curly": "error",
+    "eqeqeq": "error",
     "no-lonely-if": "error",
     "spaced-comment": ["warn", "always"],
     "capitalized-comments": [


### PR DESCRIPTION
It is considered a good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`. Also, this is a job for a linter and not a reviewer to catch.