### PR TITLE
Add rule for quotes in Typescript files

### DIFF
--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -48,6 +48,7 @@
       "rules": {
         "curly": "error",
         "no-unused-vars": "off",
+        "quotes": ["error", "single", { "avoidEscape": true }],
         "@typescript-eslint/no-unused-vars": [
           "error",
           {


### PR DESCRIPTION
The main reason for introducing this rule is to prevent usage of template literal strings if there is nothing to interpolate or the string doesn't go to multiple lines.