### PR TITLE
Use Typescript-specific rule for quotes

### DIFF
--- a/eslintrc.base.json
+++ b/eslintrc.base.json
@@ -48,7 +48,12 @@
       "rules": {
         "curly": "error",
         "no-unused-vars": "off",
-        "quotes": ["error", "single", { "avoidEscape": true }],
+        "quotes": "off",
+        "@typescript-eslint/quotes": [
+          "error",
+          "single",
+          { "avoidEscape": true }
+        ],
         "@typescript-eslint/no-unused-vars": [
           "error",
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@unocha/hpc-repo-tools",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Since we're only enforcing quote rules in Typescript files, let's use Typescript-specific linting rule. This rule extends the base [`eslint/quotes` rule](https://eslint.org/docs/latest/rules/quotes.html). It adds support for TypeScript features which allow quoted names, but not backtick quoted names.

As written in the [documentation page](https://typescript-eslint.io/rules/quotes/):
> Note: you must disable the base rule as it can report incorrect errors