### PR TITLE
Remove `@typescript-eslint/no-var-requires`

### DIFF
--- a/eslint.config.base.js
+++ b/eslint.config.base.js
@@ -114,7 +114,6 @@ module.exports = tseslint.config(
         },
       ],
       '@typescript-eslint/no-inferrable-types': 'off',
-      '@typescript-eslint/no-var-requires': 'warn',
       '@typescript-eslint/no-namespace': 'warn',
       '@typescript-eslint/no-empty-object-type': 'warn',
       '@typescript-eslint/no-non-null-assertion': 'error',


### PR DESCRIPTION
Remove deprecated rule [no-var-requires](https://typescript-eslint.io/rules/no-var-requires/ ) from `estlint.config.base.js` rules