### PR TITLE
Convert `hpc-repo-tools` to pure ESM

### DIFF
--- a/.commitlintrc.base.json
+++ b/.commitlintrc.base.json
@@ -1,9 +1,0 @@
-{
-  "rules": {
-    "body-leading-blank": [2, "always"],
-    "body-max-line-length": [2, "always", 80],
-    "body-case": [1, "always", "sentence-case"],
-    "header-case": [2, "always", "sentence-case"],
-    "header-max-length": [2, "always", 72]
-  }
-}

--- a/README.md
+++ b/README.md
@@ -12,36 +12,34 @@ and configure as follows:
 
 ### Eslint
 
-Create a `.eslintrc.js` file with the following contents:
+Create a `eslint.config.mjs` file with the following contents:
 
 ```js
-const baseConfig = require('@unocha/hpc-repo-tools/eslintrc.base');
+import baseConfig from '@unocha/hpc-repo-tools/eslint.config.base.js';
 
-module.exports = {
+export default {
   ...baseConfig,
   parserOptions: {
     project: true,
-    tsconfigRootDir: __dirname,
+    tsconfigRootDir: import.meta.dirname,
   },
 };
 ```
 
 ### Prettier
 
-Create a `.prettierrc.js` file with the following contents:
+Create a `prettier.config.mjs` file with the following contents:
 
 ```js
-module.exports = require('@unocha/hpc-repo-tools/prettier.config');
+export { default } from '@unocha/hpc-repo-tools/prettier.config.base.js';
 ```
 
 ### Commitlint
 
-Create a `.commitlintrc.json` file with the following contents:
+Create a `commitlint.config.mjs` file with the following contents:
 
-```json
-{
-  "extends": ["./node_modules/@unocha/hpc-repo-tools/.commitlintrc.base.json"]
-}
+```js
+export { default } from '@unocha/hpc-repo-tools/commitlint.config.base.js';
 ```
 
 ### Label Syncing

--- a/commitlint.config.base.js
+++ b/commitlint.config.base.js
@@ -1,0 +1,9 @@
+export default {
+  rules: {
+    'body-leading-blank': [2, 'always'],
+    'body-max-line-length': [2, 'always', 80],
+    'body-case': [1, 'always', 'sentence-case'],
+    'header-case': [2, 'always', 'sentence-case'],
+    'header-max-length': [2, 'always', 72],
+  },
+};

--- a/eslint.config.base.js
+++ b/eslint.config.base.js
@@ -1,10 +1,10 @@
-const globals = require('globals');
-const eslint = require('@eslint/js');
-const eslintConfigPrettier = require('eslint-config-prettier');
-const eslintPluginUnicorn = require('eslint-plugin-unicorn');
-const tseslint = require('typescript-eslint');
+import eslint from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
-module.exports = tseslint.config(
+export default tseslint.config(
   {
     languageOptions: {
       ecmaVersion: 2024,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.7.1",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
+  "type": "module",
   "dependencies": {
     "eslint-config-prettier": "10.0.2",
     "eslint-plugin-unicorn": "56.0.1",

--- a/prettier.config.base.js
+++ b/prettier.config.base.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   singleQuote: true,
   trailingComma: 'es5',
   plugins: ['prettier-plugin-organize-imports'],


### PR DESCRIPTION
## Nature of PR
- Bug-fix
- Hot-fix
- 🟢 Feature
- Testing
- Rewrite
- CI


## Description

When upgrading version for `eslint-plugin-unicorn` `v57.0.0`, they introduced a breaking change that require us to move from CommonJS modules to pure ESM. Beside doing this move because a third party library told us so, it will be good for us to move from CommonJS.

If this PR is approved, this will require to upgrade major version of `hpc-repo-tools` since we are adding a **BREAKING CHANGE**.

## How to test changes

To test changes, I would recommend to go to any of our existing projects, and modify the installed `hpc-repo-tools` to be written with `import/export`. After I would follow the suggestion on how to install them in projects written in `README.md`. Since now it's a ESM project, we cannot import it into CommonJS files, therefore we have to consider migrating projects to pure ESM or to change extension file name where needed to `.mjs`

## TODO:

Once (and, if) approved, review and merge #74 