### PR TITLE
Remove XML plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prettier/plugin-xml": "3.4.1",
         "eslint-config-prettier": "10.1.1",
         "eslint-plugin-unicorn": "57.0.0",
         "globals": "16.0.0",
@@ -299,18 +298,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@prettier/plugin-xml": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.1.tgz",
-      "integrity": "sha512-Uf/6/+9ez6z/IvZErgobZ2G9n1ybxF5BhCd7eMcKqfoWuOzzNUxBipNo3QAP8kRC1VD18TIo84no7LhqtyDcTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@xml-tools/parser": "^1.0.11"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -537,15 +524,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@xml-tools/parser": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
-      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chevrotain": "7.1.1"
       }
     },
     "node_modules/acorn": {
@@ -779,15 +757,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/chevrotain": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
-      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "regexp-to-ast": "0.5.0"
       }
     },
     "node_modules/ci-info": {
@@ -2252,12 +2221,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "license": "MIT"
     },
     "node_modules/regexp-tree": {
       "version": "0.1.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unocha/hpc-repo-tools",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-config-prettier": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "Apache-2.0",
   "type": "module",
   "dependencies": {
-    "@prettier/plugin-xml": "3.4.1",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-unicorn": "57.0.0",
     "globals": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
   "type": "module",

--- a/prettier.config.base.js
+++ b/prettier.config.base.js
@@ -1,10 +1,10 @@
 export default {
   singleQuote: true,
   trailingComma: 'es5',
-  plugins: [
-    '@prettier/plugin-xml',
-    'prettier-plugin-organize-imports',
-    'prettier-plugin-sh',
-  ],
+  plugins: ['prettier-plugin-organize-imports', 'prettier-plugin-sh'],
   organizeImportsSkipDestructiveCodeActions: true,
+  overrides: [
+    { files: ['*.svg'], options: { parser: 'html' } },
+    { files: ['*.xml'], options: { parser: 'html' } },
+  ],
 };

--- a/prettier.config.base.js
+++ b/prettier.config.base.js
@@ -1,6 +1,8 @@
 export default {
   singleQuote: true,
   trailingComma: 'es5',
+  htmlWhitespaceSensitivity: 'ignore',
+  bracketSameLine: true,
   plugins: ['prettier-plugin-organize-imports', 'prettier-plugin-sh'],
   organizeImportsSkipDestructiveCodeActions: true,
   overrides: [


### PR DESCRIPTION
Just after adding XML plugin in [previous release](https://github.com/UN-OCHA/hpc-repo-tools/releases/tag/v6.1.0), when trying to use it in practice in https://github.com/UN-OCHA/hpc_service/pull/3778, I've noticed some of the quirks, which weren't noticeable immediately, because the files where I noticed bad behavior were ignored from prettier formatting by mistake, until it was fixed in https://github.com/UN-OCHA/hpc_service/pull/3790.

I still want to format XML and SVG files, so I've configured HTML parser to be used for them. I don't know why this isn't by default and all the differences from standalone XML plugin and parser, but I have observed that HTML parser will just change whitespace when formatting, but not introduce potentially breaking changes, like XML. There are 2 issues I'd like to point out with XML plugin:

1. It doesn't produce output as expected. For example, in one XML file the [last two lines](https://github.com/UN-OCHA/hpc_service/blob/7c9ffe09f09dd838f0ffa185576caa5822a860c6/bin/fts/external/oct-cbpf/sample.xml#L19541-L19542) were
   ```
       </project>
       </projects>
   ```
   and the formatter just left them like that, only adding whitespace at the file end, whereas the expected output would be:
   ```
     </project>
   </projects>
   
   ```
2. The empty XML tags were collapsed to self-closing. For example, [`<Crisis_area></Crisis_area>`](https://github.com/UN-OCHA/hpc_service/blob/7c9ffe09f09dd838f0ffa185576caa5822a860c6/test/imports/edris/files/cap-reference-external.xml#L35) gets formatted as `<Crisis_area />` which could be a problem since our bridges may not properly work with self-closing tags.

Now, there is some HTML parser configuration I'd also like to change. With current configuration, we [get formatting](https://github.com/UN-OCHA/hpc-prism/blob/76b99326aae0c3b3d25fb3a1f77d4c3c454ac58d/src/app/admin/components/add-organization/addorganization.component.html#L13-L16) like this:
```html
<label for="full_name_id" class="col-form-label form-label"
  >{{ 'admin.organizations.organization-name' | translate }}
  <i class="text-danger">*</i></label
>
```
which looks a bit strange, since closing `>` from first `label` ends up on the next line, whereas closing `label` has its closing `>` alone on the last line. With the newly added settings, the same piece of code is formatted like this:
```html
<label for="full_name_id" class="col-form-label form-label">
  {{ 'admin.organizations.organization-name' | translate }}
  <i class="text-danger">*</i>
</label>
```