### PR TITLE
Allow "are" prefix in boolean var naming convention

### DIFF
--- a/eslint.config.base.js
+++ b/eslint.config.base.js
@@ -135,7 +135,7 @@ export default tseslint.config(
           selector: 'variable',
           types: ['boolean'],
           format: ['PascalCase'],
-          prefix: ['is', 'should', 'has', 'can', 'did', 'does', 'will'],
+          prefix: ['is', 'are', 'should', 'has', 'can', 'did', 'does', 'will'],
         },
         {
           selector: 'parameter',


### PR DESCRIPTION
Since we are allowing "is" prefix, which is singular, we can also allow the plural version "are".