### PR TITLE
Remove `reviewers` from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,9 @@ updates:
       timezone: 'Europe/Zurich'
     open-pull-requests-limit: 10
     versioning-strategy: increase
-    reviewers:
-      - '@UN-OCHA/hpc-js-reviewers'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
       time: '11:00'
       timezone: 'Europe/Zurich'
-    reviewers:
-      - '@UN-OCHA/hpc-js-reviewers'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Documentation for all configuration options:
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:


### PR DESCRIPTION
The Dependabot has warned us to do this with the following message:
> The `reviewers` field in the `dependabot.yml` file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners).