### PR TITLE
Update peerDependency for `eslint`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unocha/hpc-repo-tools",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-config-prettier": "10.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "yarn": ">=1.22.22"
       },
       "peerDependencies": {
-        "eslint": "^9.26.0",
+        "eslint": "^9.29.0",
         "typescript": "^5.8.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unocha/hpc-repo-tools",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Shared tooling and configuration for the HPC Development Team",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typescript-eslint": "8.38.0"
   },
   "peerDependencies": {
-    "eslint": "^9.26.0",
+    "eslint": "^9.29.0",
     "typescript": "^5.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This change is necessary since `unicorn` plugin ask for at least eslint `v9.29.0`.  If upgrading to hpc-repo-tools `v7.2.0` would linting fail if using `[v9.26.0 - v9.28.0]`